### PR TITLE
Fixed TestHostCgroupNS Test

### DIFF
--- a/connector_test.go
+++ b/connector_test.go
@@ -307,10 +307,6 @@ func TestPrivateCgroupNs(t *testing.T) {
 }
 
 func TestHostCgroupNs(t *testing.T) {
-	// get the user cgroup ns
-	if tests.IsRunningOnGithub() {
-		t.Skipf("joining host machine cgroup namespace not supported on GitHub actions")
-	}
 	logger := log.NewTestLogger(t)
 	var wg sync.WaitGroup
 

--- a/tests/common.go
+++ b/tests/common.go
@@ -86,13 +86,12 @@ func GetCommmandCgroupNs(logger log.Logger, command string, args []string) strin
 		if err := cmd2.Run(); err != nil {
 			logger.Errorf(err.Error())
 		}
-		userCgroupNs = strings.Split(stdout.String(), " ")[10]
+		stdoutStr:=stdout.String()
+		regex:=regexp.MustCompile(`.*cgroup:\[(\d+)\]`)
+		userCgroupNs = regex.ReplaceAllString(stdoutStr,"$1")
+		userCgroupNs = strings.TrimSuffix(userCgroupNs, "\n")
 	}()
 	wg.Wait()
-	// removes linux cgroup notation
-	regex := regexp.MustCompile(`cgroup:\[(\d+)\]`)
-	userCgroupNs = regex.ReplaceAllString(userCgroupNs, "$1")
-	userCgroupNs = strings.TrimSuffix(userCgroupNs, "\n")
 	return userCgroupNs
 }
 


### PR DESCRIPTION
Refactoring on cgroup namespace discovery function, repladed split + column with a regex to have a more solid implementation,  fixed a bug on namespace retrival.

## Changes introduced with this PR

Please explain your changes here.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).