### PR TITLE
Fix factory ID specified as docker

### DIFF
--- a/factory.go
+++ b/factory.go
@@ -19,7 +19,7 @@ type factory struct {
 }
 
 func (f factory) ID() string {
-	return "docker"
+	return "podman"
 }
 
 func (f factory) ConfigurationSchema() *schema.TypedScopeSchema[*Config] {


### PR DESCRIPTION
This causes problems in the engine

## Changes introduced with this PR

The factory ID was still docker, instead of podman, which caused problems.
This simply fixes the string.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).