### PR TITLE
Added --atp to invoke ATP mode

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -37,7 +37,7 @@ func (c *Connector) Deploy(ctx context.Context, image string) (deployer.Plugin, 
 		SetCgroupNs(c.config.Podman.CgroupNs).
 		SetNetworkMode(c.config.Podman.NetworkMode)
 
-	stdin, stdout, err := c.podmanCliWrapper.Deploy(image, commandArgs)
+	stdin, stdout, err := c.podmanCliWrapper.Deploy(image, commandArgs, []string{"--atp"})
 
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ func (c *Connector) pullImage(_ context.Context, image string) error {
 			c.logger.Debugf("%s: image already present skipping pull", image)
 			return nil
 		}
-		//TODO:fix default values in configuration
+		// TODO:fix default values in configuration
 
 		c.logger.Debugf("Pulling image: %s", image)
 		if err := c.podmanCliWrapper.PullImage(image, &c.config.Podman.ImageArchitecture); err != nil {

--- a/internal/cliwrapper/cliwrapper.go
+++ b/internal/cliwrapper/cliwrapper.go
@@ -63,10 +63,11 @@ func (p *cliWrapper) PullImage(image string, platform *string) error {
 	return nil
 }
 
-func (p *cliWrapper) Deploy(image string, args []string) (io.WriteCloser, io.ReadCloser, error) {
+func (p *cliWrapper) Deploy(image string, podmanArgs []string, containerArgs []string) (io.WriteCloser, io.ReadCloser, error) {
 	image = p.decorateImageName(image)
-	args = append(args, image)
-	p.deployCommand = exec.Command(p.podmanFullPath, args...) //nolint:gosec
+	podmanArgs = append(podmanArgs, image)
+	podmanArgs = append(podmanArgs, containerArgs...)
+	p.deployCommand = exec.Command(p.podmanFullPath, podmanArgs...) //nolint:gosec
 	stdin, err := p.deployCommand.StdinPipe()
 	if err != nil {
 		return nil, nil, err

--- a/internal/cliwrapper/cliwrapper_interface.go
+++ b/internal/cliwrapper/cliwrapper_interface.go
@@ -9,7 +9,8 @@ type CliWrapper interface {
 	PullImage(image string, platform *string) error
 	Deploy(
 		image string,
-		args []string,
+		podmanArgs []string,
+		containerArgs []string,
 	) (io.WriteCloser, io.ReadCloser, error)
 	KillAndClean(containerName string) error
 }


### PR DESCRIPTION
## Changes introduced with this PR

This change adds the `--atp` command line option to invoked plugins to actually invoke plugins in the ATP mode.

Test:

```
/tmp/GoLand/___go_build_go_flow_arcalot_io_engine_cmd_run_plugin -image arcaflow-example-plugin -file example.yaml -step hello-world
debugLogs: null
outputData:
    message: Hello, Arca Lot!
outputID: success
2023-02-21T17:56:38+01:00       warning         failed to kill pod arcaflow_podman_pqlN8, probably the execution terminated earlier
2023-02-21T17:56:38+01:00       info            successfully removed container arcaflow_podman_pqlN8
2023-02-21T17:56:38+01:00       info            stdin pipe successfully closed
2023-02-21T17:56:38+01:00       info            stdout pipe successfully closed
```

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).