### PR TITLE
bump golangci-lint-action version to fix ci error

### DIFF
--- a/.github/workflows/test_ci.yaml
+++ b/.github/workflows/test_ci.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Hard-coding version due to this bug: https://github.com/golangci/golangci-lint-action/issues/535
-          version: v1.47
+          version: v1.52.2
   test:
     name: go test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes introduced with this PR

Please explain your changes here.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).