### PR TITLE
correct platform parameter to OS/ARCH to fix image pull problem

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -74,6 +74,7 @@ func (c *Connector) pullImage(_ context.Context, image string) error {
 	}
 	if c.config.Deployment.ImagePullPolicy == ImagePullPolicyIfNotPresent {
 		imageExists, err := c.podmanCliWrapper.ImageExists(image)
+		podmanPlatform := c.config.Podman.ImageOS + "/" + c.config.Podman.ImageArchitecture
 		if err != nil {
 			return err
 		}
@@ -85,7 +86,7 @@ func (c *Connector) pullImage(_ context.Context, image string) error {
 		// TODO:fix default values in configuration
 
 		c.logger.Debugf("Pulling image: %s", image)
-		if err := c.podmanCliWrapper.PullImage(image, c.config.Podman.ImageOS + "/" + c.config.Podman.ImageArchitecture); err != nil {
+		if err := c.podmanCliWrapper.PullImage(image, &podmanPlatform); err != nil {
 			return err
 		}
 	}

--- a/connector.go
+++ b/connector.go
@@ -85,7 +85,7 @@ func (c *Connector) pullImage(_ context.Context, image string) error {
 		// TODO:fix default values in configuration
 
 		c.logger.Debugf("Pulling image: %s", image)
-		if err := c.podmanCliWrapper.PullImage(image, &c.config.Podman.ImageArchitecture); err != nil {
+		if err := c.podmanCliWrapper.PullImage(image, &c.config.Podman.ImageOS + "/" + &c.config.Podman.ImageArchitecture); err != nil {
 			return err
 		}
 	}

--- a/connector.go
+++ b/connector.go
@@ -85,7 +85,7 @@ func (c *Connector) pullImage(_ context.Context, image string) error {
 		// TODO:fix default values in configuration
 
 		c.logger.Debugf("Pulling image: %s", image)
-		if err := c.podmanCliWrapper.PullImage(image, &c.config.Podman.ImageOS + "/" + &c.config.Podman.ImageArchitecture); err != nil {
+		if err := c.podmanCliWrapper.PullImage(image, c.config.Podman.ImageOS + "/" + c.config.Podman.ImageArchitecture); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Changes introduced with this PR

We have been seeing image pull failures with the podman deployer related to mult-arch images. It seems that we are passing the `--platform` parameter only the architecture value when this parameter requires OS/ARCH as input. The error reported by the workflow:
```
2023-11-02T17:31:51+01:00	debug	source=deployer	Pulling image: quay.io/arcalot/arcaflow-plugin-sysbench:0.6.0
2023-11-02T17:31:53+01:00	error	source=main	Invalid workflow (invalid workflow (failed to load schema for step sysbench_loop (invalid workflow (failed to load schema for step sysbench (failed to deploy plugin from image quay.io/arcalot/arcaflow-plugin-sysbench:0.6.0 (Trying to pull quay.io/arcalot/arcaflow-plugin-sysbench:0.6.0...
Error: choosing an image from manifest list docker://quay.io/arcalot/arcaflow-plugin-sysbench:0.6.0: no image found in image index for architecture amd64, variant "", OS amd64
))))))
```
Can be exactly reproduced with the command line:
```
$ podman pull --platform amd64 quay.io/arcalot/arcaflow-plugin-sysbench:latest
Trying to pull quay.io/arcalot/arcaflow-plugin-sysbench:latest...
Error: choosing an image from manifest list docker://quay.io/arcalot/arcaflow-plugin-sysbench:latest: no image found in image index for architecture amd64, variant "", OS amd64
```

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).