### PR TITLE
Fix #46 Support for volumes with 3 parts

### DIFF
--- a/connector_test.go
+++ b/connector_test.go
@@ -113,7 +113,7 @@ var volumeConfig = `
    "deployment":{
       "host":{
          "Binds":[
-            "./tests/volume:/test"
+            "./tests/volume:/test:Z"
          ]
       }
    },
@@ -124,19 +124,11 @@ var volumeConfig = `
 `
 
 func TestSimpleVolume(t *testing.T) {
-	logger := log.NewTestLogger(t)
 	fileContent, err := os.ReadFile("./tests/volume/test_file.txt")
 	assert.NoError(t, err)
 
 	connector, _ := getConnector(t, volumeConfig)
-	cwd, err := os.Getwd()
 	assert.NoError(t, err)
-	// disable selinux on the test folder in order to make the file readable from within the container
-	cmd := exec.Command("chcon", "-Rt", "svirt_sandbox_file_t", fmt.Sprintf("%s/tests/volume", cwd)) //nolint:gosec
-	err = cmd.Run()
-	if err != nil {
-		logger.Warningf("failed to set SELinux permissions on folder, chcon error: %s, this may cause test failure if SELinux is enabled.", err.Error())
-	}
 
 	container, err := connector.Deploy(
 		context.Background(),

--- a/internal/argsbuilder/argsbuilder.go
+++ b/internal/argsbuilder/argsbuilder.go
@@ -19,7 +19,7 @@ func (a *argsBuilder) SetEnv(env []string) ArgsBuilder {
 
 func (a *argsBuilder) SetVolumes(binds []string) ArgsBuilder {
 	for _, v := range binds {
-		if tokens := strings.Split(v, ":"); len(tokens) == 2 {
+		if tokens := strings.Split(v, ":"); len(tokens) == 2 || len(tokens) == 3 {
 			*a.commandArgs = append(*a.commandArgs, "-v", v)
 		}
 	}


### PR DESCRIPTION
## Changes introduced with this PR

Fix for issue #46, this is needed for selinux enabled distros.

This enables support for 2 and 3 parts volumes:
- 2 parts: `./local:/in-container`
- 3 parts, 3rd part being security options: `./local:/in-container:z`

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).