### PR TITLE
Add support for bind mount options and clean up connector tests

### DIFF
--- a/connector_test.go
+++ b/connector_test.go
@@ -546,26 +546,24 @@ func TestClose(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// readOutputUntil helper function, reads from plugin (io.Reader) until finds lookforOutput
+// readOutputUntil is a helper function which reads from the provided io.Reader
+// until it receives the specified string or EOF; returns the bytes read.
 func readOutputUntil(t *testing.T, plugin io.Reader, lookForOutput string) []byte {
 	var n int
 	readBuffer := make([]byte, 10240)
-	for {
+	for !strings.Contains(string(readBuffer[:n]), lookForOutput) {
 		currentBuffer := make([]byte, 1024)
 		readBytes, err := plugin.Read(currentBuffer)
-		if err != nil {
-			if err != io.EOF {
-				t.Fatalf("error while reading stdout: %s", err.Error())
-			} else {
-				return readBuffer[:n]
-			}
-		}
 		copy(readBuffer[n:], currentBuffer[:readBytes])
 		n += readBytes
-		if strings.Contains(string(readBuffer[:n]), lookForOutput) {
-			return readBuffer[:n]
+
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatalf("error while reading stdout: %s", err.Error())
 		}
 	}
+	return readBuffer[:n]
 }
 
 func checkIfconfig(t *testing.T) string {

--- a/connector_test.go
+++ b/connector_test.go
@@ -96,8 +96,7 @@ func TestEnv(t *testing.T) {
 
 	t.Cleanup(func() { assert.NoError(t, container.Close()) })
 
-	var containerInput = []byte("env\n")
-	assert.NoErrorR[int](t)(container.Write(containerInput))
+	assert.NoErrorR[int](t)(container.Write([]byte("env\n")))
 
 	readBuffer := readOutputUntil(t, container, envVars)
 	assert.GreaterThan(t, len(readBuffer), 0)
@@ -132,8 +131,8 @@ func bindMountHelper(t *testing.T, options string) {
 
 	t.Cleanup(func() { assert.NoError(t, container.Close()) })
 
-	var containerInput = []byte("volume\n")
-	assert.NoErrorR[int](t)(container.Write(containerInput))
+	assert.NoErrorR[int](t)(container.Write([]byte("volume\n")))
+
 	// Note: If it ends up with length zero buffer, restarting the VM may help:
 	// https://stackoverflow.com/questions/71977532/podman-mount-host-volume-return-error-statfs-no-such-file-or-directory-in-ma
 	readBuffer := readOutputUntil(t, container, string(fileContent))
@@ -192,9 +191,8 @@ func TestContainerName(t *testing.T) {
 	assert.NoErrorR[int](t)(container1.Write(containerInput))
 	assert.NoErrorR[int](t)(container2.Write(containerInput))
 
-	// Wait for each of the containers to start running, and then wait for our
-	// go-routine to complete; arbitrarily fail the test if it doesn't all
-	// happen within 30 seconds.
+	// Wait for each of the containers to start running; arbitrarily fail the
+	// test if it doesn't all happen within 30 seconds.
 	end := time.Now().Add(30 * time.Second)
 	for !tests.IsContainerRunning(logger, cfg1.Podman.Path, container1.ID()) {
 		assert.Equals(t, time.Now().Before(end), true)
@@ -251,8 +249,8 @@ func TestCgroupNsByContainerName(t *testing.T) {
 	assert.NoErrorR[int](t)(container1.Write([]byte("sleep 7\n")))
 
 	// Wait for each of the containers to start running so that we can collect
-	// their cgroup names, and then wait for our go-routine to complete;
-	// arbitrarily fail the test if it doesn't all happen within 30 seconds.
+	// their cgroup names; arbitrarily fail the test if it doesn't all happen
+	// within 30 seconds.
 	end := time.Now().Add(30 * time.Second)
 	var ns1, ns2 string
 	for ns1 == "" {
@@ -294,8 +292,8 @@ func TestPrivateCgroupNs(t *testing.T) {
 	assert.NoErrorR[int](t)(container.Write([]byte("sleep 5\n")))
 
 	// Wait for the container to start running so that we can collect its
-	// cgroup name, and then wait for our go-routine to complete; arbitrarily
-	// fail the test if it doesn't all happen within 30 seconds.
+	// cgroup name; arbitrarily fail the test if it doesn't all happen within
+	// 30 seconds.
 	end := time.Now().Add(30 * time.Second)
 	var podmanCgroupNs string
 	for podmanCgroupNs == "" {
@@ -333,8 +331,8 @@ func TestHostCgroupNs(t *testing.T) {
 	assert.NoErrorR[int](t)(container.Write([]byte("sleep 5\n")))
 
 	// Wait for the container to start running so that we can collect its
-	// cgroup name, and then wait for our go-routine to complete; arbitrarily
-	// fail the test if it doesn't all happen within 30 seconds.
+	// cgroup name; arbitrarily fail the test if it doesn't all happen within
+	// 30 seconds.
 	end := time.Now().Add(30 * time.Second)
 	var podmanCgroupNs string
 	for podmanCgroupNs == "" {
@@ -363,8 +361,8 @@ func TestCgroupNsByNamespacePath(t *testing.T) {
 	assert.NoErrorR[int](t)(container1.Write([]byte("sleep 10\n")))
 
 	// Wait for each of the containers to start running so that we can collect
-	// their cgroup names, and then wait for our go-routine to complete;
-	// arbitrarily fail the test if it doesn't all happen within 30 seconds.
+	// their cgroup names; arbitrarily fail the test if it doesn't all happen
+	// within 30 seconds.
 	end := time.Now().Add(30 * time.Second)
 	var ns1 string
 	for ns1 == "" {

--- a/connector_test.go
+++ b/connector_test.go
@@ -113,7 +113,7 @@ var volumeConfig = `
    "deployment":{
       "host":{
          "Binds":[
-            "./tests/volume:/test"
+            "./tests/volume:/test:Z"
          ]
       }
    },
@@ -124,19 +124,11 @@ var volumeConfig = `
 `
 
 func TestSimpleVolume(t *testing.T) {
-	logger := log.NewTestLogger(t)
 	fileContent, err := os.ReadFile("./tests/volume/test_file.txt")
 	assert.NoError(t, err)
 
 	connector, _ := getConnector(t, volumeConfig)
-	cwd, err := os.Getwd()
 	assert.NoError(t, err)
-	// disable selinux on the test folder in order to make the file readable from within the container
-	cmd := exec.Command("chcon", "-Rt", "svirt_sandbox_file_t", fmt.Sprintf("%s/tests/volume", cwd)) //nolint:gosec
-	err = cmd.Run()
-	if err != nil {
-		logger.Warningf("failed to set SELinux permissions on folder, chcon error: %s, this may cause test failure if SELinux is enabled.", err.Error())
-	}
 
 	container, err := connector.Deploy(
 		context.Background(),

--- a/connector_test.go
+++ b/connector_test.go
@@ -160,7 +160,7 @@ func TestBindMount(t *testing.T) {
 		option       string
 		expectedPass bool
 	}
-	scenarios := map[string]param{
+	scenarios := map[string]*param{
 		"ReadOnly":   {":ro", true},
 		"Multiple":   {":ro,noexec", true},
 		"No options": {"", true},
@@ -168,12 +168,14 @@ func TestBindMount(t *testing.T) {
 	if tests.IsRunningOnLinux() {
 		// The SELinux options seem to cause problems on Mac OS X, so only test
 		// them on Linux.
-		scenarios["Private"] = param{":Z", true}
-		scenarios["Shared"] = param{":z", true}
+		scenarios["Private"] = &param{":Z", true}
+		scenarios["Shared"] = &param{":z", true}
 		if selinux.GetEnabled() {
 			// On Linux, bind mounts without relabeling options will fail when
 			// SELinux is enabled.  So, reset expectations appropriately.
-			scenarios["No options"] = param{scenarios["No options"].option, false}
+			scenarios["No options"].expectedPass = false
+			scenarios["ReadOnly"].expectedPass = false
+			scenarios["Multiple"].option = ":Z,ro,exec"
 		}
 
 	}

--- a/connector_test.go
+++ b/connector_test.go
@@ -296,6 +296,7 @@ func TestPrivateCgroupNs(t *testing.T) {
 }
 
 func TestHostCgroupNs(t *testing.T) {
+	//goland:noinspection GoBoolExpressions  // The linter cannot tell that this expression is not constant.
 	if runtime.GOOS != "linux" {
 		t.Skipf("Not running on Linux. Skipping cgroup test.")
 		return

--- a/connector_test.go
+++ b/connector_test.go
@@ -56,6 +56,8 @@ func TestSimpleInOut(t *testing.T) {
 		"quay.io/arcalot/podman-deployer-test-helper:0.1.0")
 	assert.NoError(t, err)
 
+	t.Cleanup(func() { assert.NoError(t, plugin.Close()) })
+
 	var containerInput = []byte("ping abc\n")
 	assert.NoErrorR[int](t)(plugin.Write(containerInput))
 
@@ -69,10 +71,6 @@ func TestSimpleInOut(t *testing.T) {
 	readBuffer = readOutputUntil(t, plugin, endStr)
 	// assert output is not empty
 	assert.Equals(t, len(readBuffer) > 0, true)
-
-	t.Cleanup(func() {
-		assert.NoError(t, plugin.Close())
-	})
 }
 
 var envConfig = `
@@ -97,15 +95,13 @@ func TestEnv(t *testing.T) {
 	container, err := connector.Deploy(context.Background(), "quay.io/arcalot/podman-deployer-test-helper:0.1.0")
 	assert.NoError(t, err)
 
+	t.Cleanup(func() { assert.NoError(t, container.Close()) })
+
 	var containerInput = []byte("env\n")
 	assert.NoErrorR[int](t)(container.Write(containerInput))
 
 	readBuffer := readOutputUntil(t, container, envVars)
 	assert.GreaterThan(t, len(readBuffer), 0)
-
-	t.Cleanup(func() {
-		assert.NoError(t, container.Close())
-	})
 }
 
 var volumeConfig = `
@@ -135,6 +131,8 @@ func TestSimpleVolume(t *testing.T) {
 		"quay.io/arcalot/podman-deployer-test-helper:0.1.0")
 	assert.NoError(t, err)
 
+	t.Cleanup(func() { assert.NoError(t, container.Close()) })
+
 	var containerInput = []byte("volume\n")
 	_, err = container.Write(containerInput)
 	assert.NoError(t, err)
@@ -142,10 +140,6 @@ func TestSimpleVolume(t *testing.T) {
 	// https://stackoverflow.com/questions/71977532/podman-mount-host-volume-return-error-statfs-no-such-file-or-directory-in-ma
 	readBuffer := readOutputUntil(t, container, string(fileContent))
 	assert.GreaterThan(t, len(readBuffer), 0)
-
-	t.Cleanup(func() {
-		assert.NoError(t, container.Close())
-	})
 }
 
 var nameTemplate = `
@@ -171,10 +165,14 @@ func TestContainerName(t *testing.T) {
 		"quay.io/arcalot/podman-deployer-test-helper:0.1.0")
 	assert.NoError(t, err)
 
+	t.Cleanup(func() { assert.NoError(t, container1.Close()) })
+
 	container2, err := connector2.Deploy(
 		ctx,
 		"quay.io/arcalot/podman-deployer-test-helper:0.1.0")
 	assert.NoError(t, err)
+
+	t.Cleanup(func() { assert.NoError(t, container2.Close()) })
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -194,11 +192,6 @@ func TestContainerName(t *testing.T) {
 	wg.Wait()
 
 	assert.Equals(t, container1.ID() != container2.ID(), true)
-
-	t.Cleanup(func() {
-		assert.NoError(t, container1.Close())
-		assert.NoError(t, container2.Close())
-	})
 }
 
 var cgroupTemplate = `
@@ -230,6 +223,8 @@ func TestCgroupNsByContainerName(t *testing.T) {
 		"quay.io/arcalot/podman-deployer-test-helper:0.1.0")
 	assert.NoError(t, err)
 
+	t.Cleanup(func() { assert.NoError(t, container1.Close()) })
+
 	containerNamePrefix2 := "test_2"
 	// The second one will join the newly created private namespace of the first container
 	configtemplate2 := fmt.Sprintf(cgroupTemplate, containerNamePrefix2, fmt.Sprintf("container:%s", container1.ID()))
@@ -238,6 +233,8 @@ func TestCgroupNsByContainerName(t *testing.T) {
 		context.Background(),
 		"quay.io/arcalot/podman-deployer-test-helper:0.1.0")
 	assert.NoError(t, err)
+
+	t.Cleanup(func() { assert.NoError(t, container2.Close()) })
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -260,11 +257,6 @@ func TestCgroupNsByContainerName(t *testing.T) {
 	ns2 := tests.GetPodmanPsNsWithFormat(logger, config.Podman.Path, container2.ID(), "{{.CGROUPNS}}")
 	assert.Equals(t, ns1 == ns2, true)
 	wg.Wait()
-
-	t.Cleanup(func() {
-		assert.NoError(t, container1.Close())
-		assert.NoError(t, container2.Close())
-	})
 }
 
 func TestPrivateCgroupNs(t *testing.T) {
@@ -286,6 +278,8 @@ func TestPrivateCgroupNs(t *testing.T) {
 		"quay.io/arcalot/podman-deployer-test-helper:0.1.0")
 	assert.NoError(t, err)
 
+	t.Cleanup(func() { assert.NoError(t, container.Close()) })
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -299,10 +293,6 @@ func TestPrivateCgroupNs(t *testing.T) {
 	wg.Wait()
 
 	assert.Equals(t, userCgroupNs != podmanCgroupNs, true)
-
-	t.Cleanup(func() {
-		assert.NoError(t, container.Close())
-	})
 }
 
 func TestHostCgroupNs(t *testing.T) {
@@ -327,6 +317,8 @@ func TestHostCgroupNs(t *testing.T) {
 		"quay.io/arcalot/podman-deployer-test-helper:0.1.0")
 	assert.NoError(t, err)
 
+	t.Cleanup(func() { assert.NoError(t, container.Close()) })
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -342,10 +334,6 @@ func TestHostCgroupNs(t *testing.T) {
 	wg.Wait()
 
 	assert.Equals(t, userCgroupNs, podmanCgroupNs)
-
-	t.Cleanup(func() {
-		assert.NoError(t, container.Close())
-	})
 }
 
 func TestCgroupNsByNamespacePath(t *testing.T) {
@@ -359,6 +347,8 @@ func TestCgroupNsByNamespacePath(t *testing.T) {
 	connector1, config := getConnector(t, configtemplate1)
 	container1, err := connector1.Deploy(context.Background(), "quay.io/arcalot/podman-deployer-test-helper:0.1.0")
 	assert.NoError(t, err)
+
+	t.Cleanup(func() { assert.NoError(t, container1.Close()) })
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -384,6 +374,8 @@ func TestCgroupNsByNamespacePath(t *testing.T) {
 		"quay.io/arcalot/podman-deployer-test-helper:0.1.0")
 	assert.NoError(t, err)
 
+	t.Cleanup(func() { assert.NoError(t, container2.Close()) })
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -396,11 +388,6 @@ func TestCgroupNsByNamespacePath(t *testing.T) {
 	ns2 := tests.GetPodmanPsNsWithFormat(logger, config.Podman.Path, container1.ID(), "{{.CGROUPNS}}")
 	assert.Equals(t, ns1 == ns2, true)
 	wg.Wait()
-
-	t.Cleanup(func() {
-		assert.NoError(t, container1.Close())
-		assert.NoError(t, container2.Close())
-	})
 }
 
 var networkTemplate = `
@@ -428,6 +415,8 @@ func TestNetworkHost(t *testing.T) {
 		"quay.io/arcalot/podman-deployer-test-helper:0.1.0")
 	assert.NoError(t, err)
 
+	t.Cleanup(func() { assert.NoError(t, plugin.Close()) })
+
 	var containerInput = []byte("network host\n")
 	// the test script will run "ifconfig" in the container
 	assert.NoErrorR[int](t)(plugin.Write(containerInput))
@@ -444,10 +433,6 @@ func TestNetworkHost(t *testing.T) {
 	readBuffer := readOutputUntil(t, plugin, ifconfigOutStr)
 	containerOutString := string(readBuffer)
 	assert.Contains(t, containerOutString, ifconfigOutStr)
-
-	t.Cleanup(func() {
-		assert.NoError(t, plugin.Close())
-	})
 }
 
 func TestNetworkBridge(t *testing.T) {
@@ -546,6 +531,8 @@ func testNetworking(t *testing.T, podmanNetworking string, containerTest string,
 		"quay.io/arcalot/podman-deployer-test-helper:0.1.0")
 	assert.NoError(t, err)
 
+	t.Cleanup(func() { assert.NoError(t, plugin.Close()) })
+
 	var containerInput = []byte(containerTest)
 	// the test script will output a string containing the desired ip address and mac address
 	// filtered by the desired interface name
@@ -572,8 +559,4 @@ func testNetworking(t *testing.T, podmanNetworking string, containerTest string,
 		assert.Contains(t, string(readBuffer), *ip)
 		assert.Contains(t, string(readBuffer), *mac)
 	}
-
-	t.Cleanup(func() {
-		assert.NoError(t, plugin.Close())
-	})
 }

--- a/connector_test.go
+++ b/connector_test.go
@@ -340,7 +340,6 @@ func TestHostCgroupNs(t *testing.T) {
 		assert.Equals(t, time.Now().Before(end), true)
 		time.Sleep(1 * time.Second)
 	}
-	assert.NotNil(t, podmanCgroupNs)
 	assert.Equals(t, userCgroupNs, podmanCgroupNs)
 }
 

--- a/connector_test.go
+++ b/connector_test.go
@@ -178,8 +178,10 @@ func TestBindMountNonLinux(t *testing.T) {
 }
 
 func TestBindMountNonSELinux(t *testing.T) {
-	if !tests.IsRunningOnLinux() || selinux.GetEnabled() {
-		t.Skip("Not running on Linux with SELinux disabled; skipping.")
+	if selinux.GetEnabled() {
+		t.Skip("SELinux is enabled; skipping.")
+	} else if !tests.IsRunningOnLinux() {
+		t.Skip("Not running on Linux; skipping.")
 	}
 
 	scenarios := map[string]*bindMountParam{

--- a/go.mod
+++ b/go.mod
@@ -14,10 +14,12 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	gotest.tools/v3 v3.5.1 // indirect
 )
 
 require (
+	github.com/opencontainers/selinux v1.11.0
 	go.arcalot.io/log/v2 v2.1.0
 	go.flow.arcalot.io/pluginsdk v0.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
+github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
+github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
 go.arcalot.io/assert v1.8.0 h1:hGcHMPncQXwQvjj7MbyOu2gg8VIBB00crUJZpeQOjxs=
 go.arcalot.io/assert v1.8.0/go.mod h1:nNmWPoNUHFyrPkNrD2aASm5yPuAfiWdB/4X7Lw3ykHk=
 go.arcalot.io/lang v1.1.0 h1:ugglRKpd3qIMkdghAjKJxsziIgHm8QpxrzZPSXoa08I=
@@ -20,6 +22,8 @@ go.flow.arcalot.io/deployer v0.5.0 h1:yXYogvL3shNBEEoTx9U9CNbfxuf8777uAH5Vn3hv1Y
 go.flow.arcalot.io/deployer v0.5.0/go.mod h1:whj8wOUursCnfZCt1a7eY5hU3EyOcUG48vM4NeAe5N8=
 go.flow.arcalot.io/pluginsdk v0.8.0 h1:cShsshrR17ZFLcbgi3aZvqexLttcp3JISFNqPUPuDvA=
 go.flow.arcalot.io/pluginsdk v0.8.0/go.mod h1:sk7ssInR/T+Gy+RSRr+QhKqZcECFFxMyn1hPQCTZSyU=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=

--- a/internal/argsbuilder/argsbuilder.go
+++ b/internal/argsbuilder/argsbuilder.go
@@ -19,7 +19,7 @@ func (a *argsBuilder) SetEnv(env []string) ArgsBuilder {
 
 func (a *argsBuilder) SetVolumes(binds []string) ArgsBuilder {
 	for _, v := range binds {
-		if tokens := strings.Split(v, ":"); len(tokens) == 2 {
+		if tokens := strings.Split(v, ":"); len(tokens) == 2 || len(tokens) == 3 {
 			*a.commandArgs = append(*a.commandArgs, "-v", v)
 		}
 	}

--- a/tests/volume/test_file.txt
+++ b/tests/volume/test_file.txt
@@ -1,1 +1,0 @@
-Hello World!


### PR DESCRIPTION
## Changes introduced with this PR

This PR is an extension of #47 and supersedes it:  this change rebases the two commits from @rh-tguittet on the end of `main`, adds a series of commits containing a sequence of fixes/enhancements to the tests, and an enhancement to the bind test which checks multiple scenarios.

I suggest reviewing each of the commits individually (they should all be squashed when this PR is merged), highlights:
- Reposition the `t.Cleanup()` invocations so that they might have a chance of being useful if the test actually fails or crashes.
- Remove the various timing `Sleep()` calls and replace them with loops which wait for the required datum to appear; this addresses at least one of the flakey tests which was failing occasionally in the CI.
- Fix a bug in `TestCgroupNsByNamespacePath()` where we were fetching the same datum _twice_ and checking that it was the same, instead of fetching the corresponding values from the two _different_ containers.
- Rework `readOutputUntil()` to avoid a bug where it might omit from the returned value the last buffer read when an error such as EOF occurs.
- Inline `checkIfconfig()`, since it's used in only one place and it could be reduced to a single line.
- Replace a number of uses of `assert.NoError()` with `assert.NoErrorR()`.
- Change the existing `TestSimpleVolume()` function into a helper function which is called repeatedly by each of three new tests which use a table to generate the various scenarios.  The three tests correspond to three host platform types -- non-Linux, SELinux, and Linux with SELinux disabled -- and the tests mark themselves as "skipped" if they don't match the host platform.  Modify the test to create the bind-mounted file on the fly, so that sharing the same file between the containers doesn't lead to conflict; tighten up the pass/fail assertion. 

Fixes #46.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).