### PR TITLE
Detect running containers to remove unnecessary error messages

### DIFF
--- a/cli_plugin.go
+++ b/cli_plugin.go
@@ -54,7 +54,7 @@ func (p *CliPlugin) Close() error {
 	}
 	switch {
 	case killErr != nil && cleanErr != nil:
-		return fmt.Errorf("error while killing pod (%s) and cleaning up pod (%s)", killErr.Error(), cleanErr.Error())
+		return fmt.Errorf("error while killing container (%s) and cleaning up container (%s)", killErr.Error(), cleanErr.Error())
 	case killErr != nil:
 		return killErr
 	case cleanErr != nil:

--- a/cli_plugin.go
+++ b/cli_plugin.go
@@ -39,7 +39,8 @@ func (p *CliPlugin) Close() error {
 		killErr = p.wrapper.Kill(p.containerName)
 	}
 
-	// Still clean up even if the kill fails.
+	// Still clean up even if the kill fails. Clean() uses the --force parameter, so that
+	// will be another attempt at killing the container.
 	cleanErr := p.wrapper.Clean(p.containerName)
 
 	if err := p.stdin.Close(); err != nil {

--- a/internal/cliwrapper/cliwrapper.go
+++ b/internal/cliwrapper/cliwrapper.go
@@ -53,9 +53,9 @@ func (p *cliWrapper) ImageExists(image string) (*bool, error) {
 	return &exists, nil
 }
 
-func (p *cliWrapper) ContainerExists(containerID string) (bool, error) {
+func (p *cliWrapper) ContainerRunning(containerID string) (bool, error) {
 	outStr, err := p.runPodmanCmd(
-		"checking whether container exists",
+		"checking whether container is running",
 		"container", "ls", "--format", "{{.Names}}",
 	)
 	if err != nil {
@@ -95,16 +95,19 @@ func (p *cliWrapper) Deploy(image string, podmanArgs []string, containerArgs []s
 	return stdin, stdout, nil
 }
 
-func (p *cliWrapper) KillAndClean(containerName string) error {
+func (p *cliWrapper) Kill(containerName string) error {
 	_, err := p.runPodmanCmd("killing container "+containerName, "kill", containerName)
 	if err != nil {
 		p.logger.Warningf("failed to kill pod %s (%s); it may have exited earlier", containerName, err.Error())
 	} else {
 		p.logger.Debugf("successfully killed container %s", containerName)
 	}
+	return nil
+}
 
+func (p *cliWrapper) Clean(containerName string) error {
 	msg := "removing container " + containerName
-	_, err = p.runPodmanCmd(msg, "rm", "--force", containerName)
+	_, err := p.runPodmanCmd(msg, "rm", "--force", containerName)
 	if err != nil {
 		p.logger.Errorf(err.Error())
 	} else {

--- a/internal/cliwrapper/cliwrapper.go
+++ b/internal/cliwrapper/cliwrapper.go
@@ -96,16 +96,15 @@ func (p *cliWrapper) Deploy(image string, podmanArgs []string, containerArgs []s
 }
 
 func (p *cliWrapper) KillAndClean(containerName string) error {
-	cmdKill := p.getPodmanCmd("kill", containerName)
-	p.logger.Debugf("Killing with command %v", cmdKill.Args)
-	if err := cmdKill.Run(); err != nil {
-		p.logger.Warningf("failed to kill pod %s; it may have exited earlier", containerName)
+	_, err := p.runPodmanCmd("killing container "+containerName, "kill", containerName)
+	if err != nil {
+		p.logger.Warningf("failed to kill pod %s (%s); it may have exited earlier", containerName, err.Error())
 	} else {
 		p.logger.Debugf("successfully killed container %s", containerName)
 	}
 
 	msg := "removing container " + containerName
-	_, err := p.runPodmanCmd(msg, "rm", "--force", containerName)
+	_, err = p.runPodmanCmd(msg, "rm", "--force", containerName)
 	if err != nil {
 		p.logger.Errorf(err.Error())
 	} else {

--- a/internal/cliwrapper/cliwrapper_interface.go
+++ b/internal/cliwrapper/cliwrapper_interface.go
@@ -6,6 +6,7 @@ import (
 
 type CliWrapper interface {
 	ImageExists(image string) (*bool, error)
+	ContainerExists(image string) (bool, error)
 	PullImage(image string, platform *string) error
 	Deploy(
 		image string,

--- a/internal/cliwrapper/cliwrapper_interface.go
+++ b/internal/cliwrapper/cliwrapper_interface.go
@@ -6,12 +6,13 @@ import (
 
 type CliWrapper interface {
 	ImageExists(image string) (*bool, error)
-	ContainerExists(image string) (bool, error)
+	ContainerRunning(image string) (bool, error)
 	PullImage(image string, platform *string) error
 	Deploy(
 		image string,
 		podmanArgs []string,
 		containerArgs []string,
 	) (io.WriteCloser, io.ReadCloser, error)
-	KillAndClean(containerName string) error
+	Kill(containerName string) error
+	Clean(containerName string) error
 }


### PR DESCRIPTION
## Changes introduced with this PR

This PR makes it so it checks to see if the container is still running. Now, the only time it will warn is if it is still running.
I also downgraded several of the messages to Debug or Info.

I also made it output the failure reason when it fails to kill the container, but you should only see that now if there is an actual problem.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).